### PR TITLE
Better screenshot feed

### DIFF
--- a/components/home/ScreenshotFeed.tsx
+++ b/components/home/ScreenshotFeed.tsx
@@ -3,7 +3,6 @@
 import classNames from "classnames";
 import { useEffect, useState } from "react";
 import PanelBar from "../ui/PanelBar";
-import StatusLight from "../ui/StatusLight";
 
 const HERO_IMAGES: string[] = [
     "https://cdn.unitystation.org/Website-Statics/heroImages/bar-engine.png",

--- a/components/home/ScreenshotFeed.tsx
+++ b/components/home/ScreenshotFeed.tsx
@@ -71,7 +71,7 @@ export default function ScreenshotFeed() {
                             />
                         ) : null,
                     )}
-                    <div className="scanlines absolute inset-0" aria-hidden />
+                    <div className="absolute inset-0" aria-hidden />
                 </div>
 
                 {/* Status bar: frame picker + counter */}

--- a/components/home/ScreenshotFeed.tsx
+++ b/components/home/ScreenshotFeed.tsx
@@ -57,11 +57,6 @@ export default function ScreenshotFeed() {
                 className="absolute -right-4 -top-4 hidden h-full w-full rounded-lg border border-seam bg-raised sm:block"
             />
             <div className="relative overflow-hidden rounded-lg border border-seam bg-panel shadow-window">
-                <PanelBar>
-                    <StatusLight tone="success" blink />
-                    <p className="type-label text-dim">In-game screenshots</p>
-                </PanelBar>
-
                 <div className="relative aspect-video bg-void xl:aspect-[16/10]">
                     {HERO_IMAGES.map((src, i) =>
                         loaded.has(i) ? (
@@ -104,6 +99,7 @@ export default function ScreenshotFeed() {
                             />
                         ))}
                     </div>
+                    <p className="type-label text-dim">In-game screenshots</p>
                     <p className="type-label text-faint">
                         {String(frame + 1).padStart(2, "0")} /{" "}
                         {String(HERO_IMAGES.length).padStart(2, "0")}


### PR DESCRIPTION
<img width="867" height="550" alt="image" src="https://github.com/user-attachments/assets/f3494d3c-606e-494b-9a54-1567c2243d44" />

Makes it not look as generic to avoid problems where our human lizard brains can mistake this for AI slop due to a function our brain has that is called "pattern recognition"

also uncentered text is a vital component to the unitystation experience 